### PR TITLE
Fix tmux comment typo

### DIFF
--- a/home/dot_tmux.conf
+++ b/home/dot_tmux.conf
@@ -1,4 +1,4 @@
-# tpm boostrap
+# tpm bootstrap
 if "test ! -d ~/.tmux/plugins/tpm" \
   "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm'"
 


### PR DESCRIPTION
## Summary
- fix tpm bootstrap comment typo

## Testing
- `grep -n "# tpm" -n home/dot_tmux.conf`

------
https://chatgpt.com/codex/tasks/task_e_6878cbd3be388330a30c3c3b2b8f1e73