### PR TITLE
fix CI for ubuntu: swap neofetch→fastfetch and drop ubuntu:24.04 from matrix

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["archlinux:latest", "cachyos/cachyos:latest", "ubuntu:24.04", "ubuntu:latest"]
+        container: ["archlinux:latest", "cachyos/cachyos:latest", "ubuntu:latest"]
     container:
       image: ${{ matrix.container }}
       env:

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -102,6 +102,7 @@ packages:
       - cmake
       - curl
       - eza
+      - fastfetch
       - fd-find
       - fish
       - fzf
@@ -110,7 +111,6 @@ packages:
       - glab
       - ibus-chewing
       - kitty
-      - neofetch
       - neovim
       - nethogs
       - podman


### PR DESCRIPTION
## Summary

Two-commit fix to make the Ubuntu CI job actually represent reality.

1. **Swap `neofetch` → `fastfetch` in Ubuntu apt list.** neofetch is unmaintained and was dropped from Ubuntu apt around 25.x, so `ubuntu:latest` (currently 26.04 \"resolute\") was failing on \`apt install neofetch\` — masked by `continue-on-error: true` in the matrix. fastfetch is actively maintained and already used by the Brewfile and Arch package list, so this also unifies the system-info tool.

2. **Drop `ubuntu:24.04` from the CI matrix.** noble doesn't have fastfetch in apt (it landed in oracular 24.10+). Per README, Ubuntu is CI-only and not actively maintained for daily use, so testing one Ubuntu release is enough. Keeping `ubuntu:latest` exercises whatever modern Ubuntu apt looks like at any given time, which is more useful than pinning to a 2-year-old LTS.

## Test plan

- [ ] CI: `ubuntu:latest` passes (the original failure)
- [ ] CI: `archlinux:latest`, `cachyos:latest`, `macos:latest` unaffected
- [ ] Matrix has 4 jobs after this change (was 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)