### PR TITLE
unmask distro CI failures in workflow status

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -13,7 +13,6 @@ jobs:
   deploy-on-linux:
     name: ${{ matrix.container }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Currently the Linux matrix job has `continue-on-error: true`, which means a single distro failure does **not** turn the workflow red — the overall run reports ✓ even when one matrix cell exited 1. This actively hid a real `ubuntu:latest` failure for multiple commits (apt couldn't find `neofetch`) because every push showed green.

This PR removes that line so distro failures bubble up to the workflow status as expected. `fail-fast: false` stays — we still want every distro's result, just not silently-as-OK.

## Evidence the masking was happening

- Run [25457624789](https://github.com/CollieIsCute/dotfiles/actions/runs/25457624789) (commit \`6dc1470\`, on main): top-level ✓ success, but the `ubuntu:latest` job inside it shows ✗ \"Process completed with exit code 1.\" The whole `gh run list --status failure` query missed this kind of run because the workflow itself is reported successful.

## Test plan

- [ ] CI on this branch should produce a red ✗ overall status if any distro fails (pair with PR #20 to verify: once #20 lands first, ubuntu:latest passes; without #20, this branch should now visibly fail at the workflow level)

## Related

- #20 fixes the underlying `neofetch` failure on `ubuntu:latest`. That PR + this PR together restore both correctness (ubuntu actually installs) and observability (failures aren't masked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)