### PR TITLE
gate hyprland workspace pinning per host

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,0 +1,4 @@
+{{- $location := promptChoiceOnce . "location" "Where is this machine?" (list "home" "office") -}}
+
+[data]
+  location = {{ $location | quote }}

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,9 +1,0 @@
-{{- $location := "home" -}}
-{{- if hasKey . "location" -}}
-{{-   $location = .location -}}
-{{- else if stdinIsATTY -}}
-{{-   $location = promptChoice "Where is this machine?" (list "home" "office") "home" -}}
-{{- end }}
-
-[data]
-  location = {{ $location | quote }}

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,4 +1,9 @@
-{{- $location := promptChoiceOnce . "location" "Where is this machine?" (list "home" "office") "home" -}}
+{{- $location := "home" -}}
+{{- if hasKey . "location" -}}
+{{-   $location = .location -}}
+{{- else if stdinIsATTY -}}
+{{-   $location = promptChoice "Where is this machine?" (list "home" "office") "home" -}}
+{{- end }}
 
 [data]
   location = {{ $location | quote }}

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -1,4 +1,4 @@
-{{- $location := promptChoiceOnce . "location" "Where is this machine?" (list "home" "office") -}}
+{{- $location := promptChoiceOnce . "location" "Where is this machine?" (list "home" "office") "home" -}}
 
 [data]
   location = {{ $location | quote }}

--- a/home/dot_config/hypr/hyprland.conf.tmpl
+++ b/home/dot_config/hypr/hyprland.conf.tmpl
@@ -346,19 +346,16 @@ bindl = , XF86AudioPrev, exec, playerctl previous
 # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
 # See https://wiki.hyprland.org/Configuring/Workspace-Rules/ for workspace rules
 
-# Pin ws1/2/3 left-to-right per host. desc rules cannot be left "inert"
-# because Hyprland's findAvailableDefaultWS() reserves the slot even when
-# the monitor isn't connected (it compares the rule string against the
-# connected monitor's name without resolving desc:), so the rules must
-# match the host actually running this config.
-{{- if eq .location "office" }}
+# Office: pin ws1/2/3 to the BenQ/BenQ/Dell monitors (left-to-right).
+# Only emit when this is the office host: a desc-keyed rule would
+# otherwise reserve the slot at home (Hyprland's findAvailableDefaultWS()
+# compares the rule string against the connected monitor's name without
+# resolving desc:), pushing home monitors to ws4/5/6. With no rules at
+# home, Hyprland's default per-monitor workspace assignment gives 1/2/3.
+{{- if eq (index . "location") "office" }}
 workspace = 1, monitor:desc:BNQ BenQ GC2870 51J06421019, default:true
 workspace = 2, monitor:desc:BNQ BenQ GW2790, default:true
 workspace = 3, monitor:desc:Dell Inc. DELL P2214H 20C1Y64C5EEL, default:true
-{{- else if eq .location "home" }}
-workspace = 1, monitor:desc:Acer Technologies XV272U RV, default:true
-workspace = 2, monitor:desc:ASUSTek COMPUTER INC PG27AQDM, default:true
-workspace = 3, monitor:desc:Microstep MSI MP242, default:true
 {{- end }}
 
 # Ignore maximize requests from apps. You'll probably like this.

--- a/home/dot_config/hypr/hyprland.conf.tmpl
+++ b/home/dot_config/hypr/hyprland.conf.tmpl
@@ -346,11 +346,20 @@ bindl = , XF86AudioPrev, exec, playerctl previous
 # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
 # See https://wiki.hyprland.org/Configuring/Workspace-Rules/ for workspace rules
 
-# Office monitors: pin ws1/2/3 left-to-right.
-# Inert at home — desc lookup is a no-op when the monitor isn't connected.
+# Pin ws1/2/3 left-to-right per host. desc rules cannot be left "inert"
+# because Hyprland's findAvailableDefaultWS() reserves the slot even when
+# the monitor isn't connected (it compares the rule string against the
+# connected monitor's name without resolving desc:), so the rules must
+# match the host actually running this config.
+{{- if eq .location "office" }}
 workspace = 1, monitor:desc:BNQ BenQ GC2870 51J06421019, default:true
 workspace = 2, monitor:desc:BNQ BenQ GW2790, default:true
 workspace = 3, monitor:desc:Dell Inc. DELL P2214H 20C1Y64C5EEL, default:true
+{{- else if eq .location "home" }}
+workspace = 1, monitor:desc:Acer Technologies XV272U RV, default:true
+workspace = 2, monitor:desc:ASUSTek COMPUTER INC PG27AQDM, default:true
+workspace = 3, monitor:desc:Microstep MSI MP242, default:true
+{{- end }}
 
 # Ignore maximize requests from apps. You'll probably like this.
 windowrule {


### PR DESCRIPTION
## Summary

At home the monitors land on ws4/5/6 because the office workspace pinning rules reserve slots 1/2/3 even when those monitors are disconnected.

This PR: emit the office pinning rules **only when this is the office host**, so home (and CI, and any other host) falls through to Hyprland's default behaviour, which already gives ws1/2/3 to connected monitors in order.

## Root cause

Hyprland's `CMonitor::findAvailableDefaultWS()` (`src/helpers/Monitor.cpp`) iterates workspace IDs from 1 and skips any ID whose rule has `monitor:` set to a string that isn't the current monitor's `name`. The rule string is compared verbatim — `desc:` is **not** resolved. Result: with the BenQ/Dell monitors disconnected, the rule strings `"desc:BNQ BenQ GC2870..."` etc. never match `"DP-1"` (or whatever home monitor port name), so IDs 1/2/3 are skipped and home monitors get 4/5/6. See [discussion #11513](https://github.com/hyprwm/Hyprland/discussions/11513).

## Fix

`hyprland.conf` → `hyprland.conf.tmpl`:

```
{{- if eq (index . "location") "office" }}
workspace = 1, monitor:desc:BNQ BenQ GC2870 51J06421019, default:true
workspace = 2, monitor:desc:BNQ BenQ GW2790, default:true
workspace = 3, monitor:desc:Dell Inc. DELL P2214H 20C1Y64C5EEL, default:true
{{- end }}
```

`index . "location"` returns nil when `.location` isn't set, which `eq` against `"office"` cleanly evaluates to false — no init prompt or `.chezmoi.toml.tmpl` needed.

## Migration

| Host | What to do |
|---|---|
| Home | nothing — no `[data] location` means no rules, default behaviour gives ws1/2/3 |
| Office | once: edit `~/.config/chezmoi/chezmoi.toml` → add `[data]\n  location = "office"`, then `chezmoi apply` |
| CI / fresh install | nothing — defaults to home behaviour |

## Test plan

- [ ] Home machine after `chezmoi apply`: Acer/ASUS/MSI land on ws1/2/3
- [ ] Office machine after setting `[data] location = "office"` and `chezmoi apply`: BenQ/BenQ/Dell pin to ws1/2/3 (unchanged from before)
- [ ] CI: no `.location` → no rules emitted → existing test passes

## References

- [Hyprland src/helpers/Monitor.cpp — findAvailableDefaultWS](https://github.com/hyprwm/Hyprland/blob/main/src/helpers/Monitor.cpp)
- [Discussion #11513 — workspace default isn't inert when monitor missing](https://github.com/hyprwm/Hyprland/discussions/11513)

🤖 Generated with [Claude Code](https://claude.com/claude-code)