### PR TITLE
ignore the .claude/ directory at the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 home/dot_config/tmux/plugins/
 tmux-client-*.log
 .sisyphus/
+.claude/


### PR DESCRIPTION
## Summary

Add `.claude/` to `.gitignore`. Claude Code drops a `.claude/` directory (containing `settings.local.json`, agent state, etc.) into any working directory it operates in. The contents are per-machine and per-session — they shouldn't be tracked, but the warning kept popping up on every status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)