### PR TITLE
drop dwindle:pseudotile removed in Hyprland 0.55

### DIFF
--- a/home/dot_config/hypr/hyprland.conf.tmpl
+++ b/home/dot_config/hypr/hyprland.conf.tmpl
@@ -212,7 +212,6 @@ animations {
 
 # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
 dwindle {
-    pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
     preserve_split = true # You probably want this
 }
 


### PR DESCRIPTION
## Summary
- Hyprland 0.55.0 removed the `dwindle:pseudotile` global option, triggering a startup config error on line 215 of `~/.config/hypr/hyprland.conf`.
- Drop the line; keep `preserve_split` and the `pseudo` dispatcher keybind (per-window pseudotile still works via `$mainMod+P`).

Upstream changelog: *"dwindle:pseudotile has been removed as it wasn't doing anything"* — [Hyprland v0.55.0 release notes](https://github.com/hyprwm/Hyprland/releases/tag/v0.55.0).

## Test plan
- [ ] `chezmoi apply` and reload Hyprland (`hyprctl reload`) — no config error
- [ ] `journalctl --user -u Hyprland` clean of `config error` lines
- [ ] `$mainMod+P` still toggles pseudotile on the focused window

🤖 Generated with [Claude Code](https://claude.com/claude-code)