### PR TITLE
Update OMO schema reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ home/dot_config/tmux/plugins/
 tmux-client-*.log
 .sisyphus/
 .claude/
+.omo/

--- a/home/dot_config/opencode/oh-my-openagent.json
+++ b/home/dot_config/opencode/oh-my-openagent.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
   "agents": {
     "build": {
       "model": "openai/gpt-5.5",


### PR DESCRIPTION
## Summary
- Point OMO schema at upstream `oh-my-openagent/dev` and ignore generated `.omo/` state.

## Validation
- Confirmed schema URL swap with `rg`; old `oh-my-opencode/master` URL is absent.
- Validated both OpenCode JSON files, `.omo/` ignore behavior, `bunx oh-my-opencode doctor --verbose`, chezmoi dry-run, and `git diff --check`.