### PR TITLE
prefer Taiwan Chinese in opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Then `chezmoi apply`.
 - Build / dev: [`gnu-tar`](https://www.gnu.org/software/tar/), [`bear`](https://github.com/rizsotto/Bear), [`cmake`](https://cmake.org), [`mold`](https://github.com/rui314/mold), [`ninja`](https://ninja-build.org), [`llvm`](https://llvm.org), [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html), [`cppcheck`](https://cppcheck.sourceforge.io), [`uv`](https://github.com/astral-sh/uv).
 - Containers: [`podman`](https://podman.io).
 - Docs: [`hugo`](https://gohugo.io), [`typst`](https://typst.app), [`tldr`](https://tldr.sh).
+- OpenCode zh-TW linting: [`zhtw-mcp`](https://github.com/sysprog21/zhtw-mcp) is configured as a local MCP server at `~/.local/bin/zhtw-mcp`. Until upstream publishes releases, install it from source with `make install` so OpenCode can use the fixed binary path.
 
 ### Fish plugins (managed by [`fisher`](https://github.com/jorgebucaran/fisher))
 

--- a/home/dot_config/opencode/instructions/zh-tw.md
+++ b/home/dot_config/opencode/instructions/zh-tw.md
@@ -1,0 +1,7 @@
+# Traditional Chinese Output
+
+When replying in Chinese, write in Traditional Chinese for Taiwan (`zh-TW`). Prefer Taiwan terminology, Ministry of Education standard character forms, and Taiwan punctuation conventions.
+
+Avoid Mainland China vocabulary, Simplified Chinese characters, and zh-CN punctuation conventions. Use examples such as `軟體`, `記憶體`, `預設`, `檔案`, `行程`, `遞迴`, `演算法`, `走訪`, `連結串列`, and `算繪` when those technical meanings apply.
+
+When Chinese user-facing prose is substantial, use the `zhtw-mcp` MCP server before responding: run the `zhtw` tool with `profile: "strict"`, `fix_mode: "lexical_safe"`, `content_type: "markdown"`, and `max_errors: 0`. Apply safe corrections before sending the final answer.

--- a/home/dot_config/opencode/opencode.json
+++ b/home/dot_config/opencode/opencode.json
@@ -2,5 +2,17 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "oh-my-openagent@latest"
+  ],
+  "mcp": {
+    "zhtw-mcp": {
+      "type": "local",
+      "command": [
+        "zhtw-mcp"
+      ],
+      "enabled": true
+    }
+  },
+  "instructions": [
+    "./instructions/zh-tw.md"
   ]
 }

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -13,6 +13,6 @@
     }
   },
   "instructions": [
-    "./instructions/zh-tw.md"
+    "{{ .chezmoi.homeDir }}/.config/opencode/instructions/zh-tw.md"
   ]
 }

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -7,7 +7,7 @@
     "zhtw-mcp": {
       "type": "local",
       "command": [
-        "zhtw-mcp"
+        "{{ .chezmoi.homeDir }}/.local/bin/zhtw-mcp"
       ],
       "enabled": true
     }


### PR DESCRIPTION
## Summary
- configure opencode to load a zh-TW instruction file through a chezmoi-rendered absolute instruction path
- register zhtw-mcp as a local MCP server through a chezmoi-rendered fixed binary path
- document the zhtw-mcp source-install prerequisite until upstream publishes releases

## Verification
- chezmoi execute-template < home/dot_config/opencode/opencode.json.tmpl > /tmp/opencode/opencode-rendered.json
- python -m json.tool /tmp/opencode/opencode-rendered.json
- from /tmp/opencode, opencode debug config shows /home/collie/.config/opencode/instructions/zh-tw.md and /home/collie/.local/bin/zhtw-mcp
- opencode mcp list shows zhtw-mcp connected at /home/collie/.local/bin/zhtw-mcp after installing the upstream make-built binary there
- zhtw-mcp lint flags 軟件 -> 軟體 and 內存 -> 記憶體