### PR TITLE
Add context7 MCP to OpenCode

### DIFF
--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -4,6 +4,15 @@
     "@bybrawe/opencode-loop@0.5.1"
   ],
   "mcp": {
+    "context7": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "enabled": true
+    },
     "zhtw-mcp": {
       "type": "local",
       "command": [


### PR DESCRIPTION
## Summary
- add context7 as an OpenCode local MCP server
- use the existing Claude Code context7 command: npx -y @upstash/context7-mcp

## Verification
- chezmoi execute-template < home/dot_config/opencode/opencode.json.tmpl | jq . > /dev/null
- checked staged diff for secret-looking keys before commit