### PR TITLE
Use push-only branch CI

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -1,6 +1,6 @@
 name: Test Dotfiles on Different OS
 
-on: [push, pull_request]
+on: [push]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
CI 只在 push 時觸發，feature branch 和 PR 都共用同一個 branch check。\n同一個 branch 的新 push 會取消舊 run，避免重複測試。\n移除 workflow_dispatch 和 pull_request，讓 workflow 保持最小。