### PR TITLE
Add Claude Code provider plugin to OpenCode

### DIFF
--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -1,7 +1,8 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "@bybrawe/opencode-loop@0.5.1"
+    "@bybrawe/opencode-loop@0.5.1",
+    "@khalilgharbaoui/opencode-claude-code-plugin@0.5.1"
   ],
   "mcp": {
     "context7": {


### PR DESCRIPTION
## Summary
- add @khalilgharbaoui/opencode-claude-code-plugin@0.5.1 to OpenCode plugins
- keep model selection manual in OpenCode instead of forcing model/small_model defaults

## Security
- no Claude token, API key, URL, or auth material is committed
- this relies on the local Claude Code CLI already being initialized by the user
- no claude commands were run during verification

## Verification
- npm metadata/README reviewed for plugin configuration
- opencode config schema checked for model/small_model behavior
- chezmoi execute-template < home/dot_config/opencode/opencode.json.tmpl | jq . > /dev/null
- checked final diff for Redmine URL and secret-looking keys