### PR TITLE
Fix Hyprland Lua dispatcher usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Then `chezmoi apply`.
 
 ### Hyprland
 
-- 6 `monitorv2` blocks (3 home + 3 office) — desc-keyed so the right machine picks the right monitors automatically.
+- 6 Lua `hl.monitor(...)` rules (3 home + 3 office) — desc-keyed so the right machine picks the right monitors automatically.
 - Cursor: Catppuccin Mocha Teal (Hyprcursor) with Catppuccin Mocha Green as XCursor fallback.
 - Electron / fcitx5 / GTK theming env vars set centrally.
 
@@ -82,7 +82,7 @@ Then `chezmoi apply`.
 | `SUPER+M` | exit Hyprland |
 | `SUPER+V` | toggle floating |
 | `SUPER+P` | pseudotile |
-| `SUPER+RETURN` | maximize |
+| `SUPER+RETURN` | true fullscreen |
 | `SUPER+N` | toggle SwayNC |
 | `SUPER+S` | toggle scratchpad workspace |
 | `SUPER+SHIFT+S` | move window to scratchpad |
@@ -90,7 +90,7 @@ Then `chezmoi apply`.
 | `ALT+L` | hyprlock |
 | `ALT+J` | toggle split |
 | `ALT+P` | hyprshot region → clipboard |
-| `CTRL+RETURN` | true fullscreen |
+| `CTRL+RETURN` | maximize |
 | `SUPER+H/J/K/L` | focus left/down/up/right |
 | `SUPER+1..9,0` | switch workspace 1..10 |
 | `SUPER+SHIFT+1..9,0` | move window to workspace |

--- a/home/dot_config/hypr/hypridle.conf
+++ b/home/dot_config/hypr/hypridle.conf
@@ -2,7 +2,7 @@ general {
   lock_cmd = pidof hyprlock || hyprlock
   on_unlock_cmd = notify-send "unlock!"
   before_sleep_cmd = loginctl lock-session
-  after_sleep_cmd = hyprctl dispatch dpms on
+  after_sleep_cmd = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })'
   inhibit_sleep = 3
 }
 
@@ -19,7 +19,6 @@ listener {
 
 listener {
   timeout = 600
-  on-timeout = hyprctl dispatch dpms off
-  on-resume  = hyprctl dispatch dpms on && brightnessctl -r
+  on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "disable" })'
+  on-resume  = hyprctl dispatch 'hl.dsp.dpms({ action = "enable" })' && brightnessctl -r
 }
-

--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -123,11 +123,11 @@ hl.config({
     },
 })
 
-hl.permission("/usr/(bin|local/bin)/grim",                            "screencopy", "allow")
-hl.permission("/usr/(lib|libexec|lib64)/xdg-desktop-portal-hyprland", "screencopy", "allow")
-hl.permission("/usr/(bin|local/bin)/hyprpm",                          "plugin",     "allow")
-hl.permission("/usr/(bin|local/bin)/hyprlock",                        "screencopy", "allow")
-hl.permission("/usr/bin/hyprshot",                                    "screencopy", "allow")
+hl.permission({ binary = "/usr/(bin|local/bin)/grim",                            type = "screencopy", mode = "allow" })
+hl.permission({ binary = "/usr/(lib|libexec|lib64)/xdg-desktop-portal-hyprland", type = "screencopy", mode = "allow" })
+hl.permission({ binary = "/usr/(bin|local/bin)/hyprpm",                          type = "plugin",     mode = "allow" })
+hl.permission({ binary = "/usr/(bin|local/bin)/hyprlock",                        type = "screencopy", mode = "allow" })
+hl.permission({ binary = "/usr/bin/hyprshot",                                    type = "screencopy", mode = "allow" })
 
 
 -----------------------

--- a/home/dot_config/waybar/scripts/executable_power-menu.sh
+++ b/home/dot_config/waybar/scripts/executable_power-menu.sh
@@ -8,7 +8,7 @@ case $choice in
         hyprlock
         ;;
     "🏠 Logout")
-        hyprctl dispatch exit
+        hyprctl dispatch 'hl.dsp.exit()'
         ;;
     "🔄 Reboot")
         systemctl reboot

--- a/home/dot_config/waybar/style.css
+++ b/home/dot_config/waybar/style.css
@@ -70,7 +70,7 @@ button:hover {
 #network,
 #pulseaudio,
 #wireplumber,
-#custom-media,
+#custom-music,
 #tray,
 #mode,
 #idle_inhibitor,
@@ -188,18 +188,18 @@ label:focus {
     color: @subtext0;
 }
 
-#custom-media {
+#custom-music {
     background-color: @surface0;
     color: @green;
     min-width: 100px;
 }
 
-#custom-media.custom-spotify {
+#custom-music.custom-spotify {
     background-color: @surface0;
     color: @green;
 }
 
-#custom-media.custom-vlc {
+#custom-music.custom-vlc {
     background-color: @surface0;
     color: @peach;
 }


### PR DESCRIPTION
## Summary
- update hypridle and Waybar logout actions to use Hyprland 0.55 Lua dispatchers
- align Hyprland permission rules with table-style Lua docs
- fix Waybar custom music CSS selector and README Hyprland notes

## Verification
- chezmoi apply -- ~/.config/hypr/hypridle.conf ~/.config/hypr/hyprland.lua ~/.config/waybar/style.css ~/.config/waybar/scripts/power-menu.sh
- chezmoi diff -- ~/.config/hypr/hypridle.conf ~/.config/hypr/hyprland.lua ~/.config/waybar/style.css ~/.config/waybar/scripts/power-menu.sh
- hyprctl configerrors
- bash -n /home/collie/.config/waybar/scripts/power-menu.sh

## Notes
- remote-setup.sh is intentionally left unmanaged and unchanged.
- logout/exit and DPMS disable were not executed to avoid ending the session or turning off displays.