### PR TITLE
Add respond-structured skill

### DIFF
--- a/home/dot_claude/skills/respond-structured/SKILL.md
+++ b/home/dot_claude/skills/respond-structured/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: respond-structured
+description: Use when the user wants a structured, scannable response instead of prose: headers, bullets, numbered lists, hierarchy, one phrase per line, diff patches, or ASCII diagrams.
+---
+
+# Respond Structured
+
+Favor structure over paragraphs.
+
+Use only as much structure as the content warrants. Flat content stays flat; do not force hierarchy that is not there.
+
+Use:
+- headers
+- short bullets
+- numbered lists
+- one phrase per line
+- concise hierarchy
+
+When code changes are involved:
+- include a diff patch when it makes the change easier to understand
+- omit the diff patch when it adds noise or duplicates an already clear explanation
+
+When visual structure helps:
+- include ASCII flowcharts
+- include ASCII Gantt charts
+- include ASCII structure diagrams
+- include ASCII class diagrams
+
+Avoid:
+- dense paragraphs
+- unnecessary nesting
+- decorative diagrams that do not clarify the answer
+- structure that adds no clarity
+
+Goal:
+Make the answer easy to scan while preserving the right amount of detail.


### PR DESCRIPTION
- 新增 `respond-structured` skill，讓回覆優先使用標題、條列、短句與適度階層。
- 放在 Claude-compatible skills 路徑，經由 chezmoi 部署到 `~/.claude/skills/respond-structured/SKILL.md`，讓 Claude Code 與 OpenCode 都能掃描。
- 補充可讀性規則：程式碼修改說明可加入 diffpatch；流程、排程、結構或類別說明可加入有幫助的 ASCII 圖。驗證：`git diff --check`、`chezmoi apply --dry-run --verbose`、`chezmoi apply --verbose`。