### PR TITLE
Allow Claude WebSearch

### DIFF
--- a/home/dot_claude/private_settings.json
+++ b/home/dot_claude/private_settings.json
@@ -15,7 +15,8 @@
       "mcp__opencode_proxy__webfetch",
       "mcp__opencode_proxy__task",
       "mcp__context7",
-      "mcp__zhtw-mcp__zhtw"
+      "mcp__zhtw-mcp__zhtw",
+      "WebSearch"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Allow Claude Code's built-in WebSearch tool in managed Claude settings
- Keep OpenCode Claude Code plugin webSearch routing on the existing Claude-native mode

## Verification
- jq empty home/dot_claude/private_settings.json
- chezmoi diff /home/collie/.claude/settings.json
- git diff --check