### PR TITLE
Add platform-specific chezmoi ignore rules

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -1,0 +1,36 @@
+# macOS-only targets.
+{{- if ne .chezmoi.os "darwin" }}
+.config/aerospace
+.config/aerospace/**
+.config/brew
+.config/brew/**
+.config/karabiner
+.config/karabiner/**
+{{- end }}
+
+# Linux desktop / XDG targets.
+{{- if ne .chezmoi.os "linux" }}
+.config/code-flags.conf
+.config/cursor-flags.conf
+.config/electron-flags.conf
+.config/environment.d
+.config/environment.d/**
+.config/hypr
+.config/hypr/**
+.config/mimeapps.list
+.config/paru
+.config/paru/**
+.config/rofi
+.config/rofi/**
+.config/swaync
+.config/swaync/**
+.config/waybar
+.config/waybar/**
+.config/wallpapers
+.config/wallpapers/**
+.local/share/applications
+.local/share/applications/**
+{{- else if not (or (eq .chezmoi.osRelease.id "arch") (eq .chezmoi.osRelease.id "cachyos")) }}
+.config/paru
+.config/paru/**
+{{- end }}


### PR DESCRIPTION
## Summary
- add a template-based .chezmoiignore for platform-specific targets
- keep Brave settings managed on macOS
- ignore Linux desktop/XDG targets on non-Linux and paru outside Arch/CachyOS

## Local verification
- chezmoi ignored
- chezmoi managed --include=files,dirs
- chezmoi apply --dry-run --verbose

## Local cleanup
- removed existing macOS copies of Linux-only target files/directories
- preserved Brave, Homebrew, AeroSpace, Karabiner, and 20-homebrew.conf