### PR TITLE
fix: prefer Wayland GTK input frontend

### DIFF
--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -106,7 +106,6 @@ hl.env("QT_QPA_PLATFORMTHEME",         "qt6ct")
 hl.env("QT_STYLE_OVERRIDE",            "kvantum")
 
 -- fcitx5 input method
-hl.env("GTK_IM_MODULE",                "fcitx")
 hl.env("QT_IM_MODULE",                 "fcitx")
 hl.env("XMODIFIERS",                   "@im=fcitx")
 


### PR DESCRIPTION
## Summary
- remove global GTK_IM_MODULE from Hyprland environment setup
- keep Qt and XWayland Fcitx variables for compatibility

## Verification
- chezmoi apply --dry-run --verbose ~/.config/hypr/hyprland.lua
- luac -p /home/collie/.config/hypr/hyprland.lua
- git diff --check