### PR TITLE
Update Noctalia status bar

### DIFF
--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -112,7 +112,7 @@ end = ["media", "group:sys-status", "volume", "battery", "clock", "notifications
 
 [[bar.main.capsule_group]]
 id = "sys-status"
-members = ["net-down", "net-up", "cpu", "temp", "ram", "disk"]
+members = ["net-down", "net-up", "cpu", "temp", "ram"]
 fill = "surface_variant"
 padding = 6.0
 opacity = 0.8
@@ -148,12 +148,6 @@ display = "text"
 [widget.ram]
 type = "sysmon"
 stat = "ram_pct"
-display = "text"
-
-[widget.disk]
-type = "sysmon"
-stat = "disk_pct"
-path = "/"
 display = "text"
 
 [widget.volume]

--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -96,7 +96,7 @@ reserve_space = true
 layer = "top"
 thickness = 30
 background_opacity = 1.0
-radius = 10
+radius = 0
 margin_ends = 0
 margin_edge = 0
 padding = 10
@@ -108,7 +108,14 @@ capsule_fill = "surface_variant"
 capsule_opacity = 0.8
 start = ["workspaces"]
 center = ["tray"]
-end = ["media", "net-down", "net-up", "cpu", "volume", "battery", "clock", "notifications", "clipboard", "session"]
+end = ["media", "group:sys-status", "volume", "battery", "clock", "notifications", "clipboard", "session"]
+
+[[bar.main.capsule_group]]
+id = "sys-status"
+members = ["net-down", "net-up", "cpu", "temp", "ram", "disk"]
+fill = "surface_variant"
+padding = 6.0
+opacity = 0.8
 
 [widget.clock]
 format = "{:%H:%M:%S}"
@@ -131,6 +138,22 @@ display = "text"
 [widget.cpu]
 type = "sysmon"
 stat = "cpu_usage"
+display = "text"
+
+[widget.temp]
+type = "sysmon"
+stat = "cpu_temp"
+display = "text"
+
+[widget.ram]
+type = "sysmon"
+stat = "ram_pct"
+display = "text"
+
+[widget.disk]
+type = "sysmon"
+stat = "disk_pct"
+path = "/"
 display = "text"
 
 [widget.volume]

--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -112,7 +112,7 @@ end = ["media", "group:sys-status", "volume", "battery", "clock", "notifications
 
 [[bar.main.capsule_group]]
 id = "sys-status"
-members = ["net-down", "net-up", "cpu", "temp", "ram"]
+members = ["net-down", "net-up", "cpu", "ram", "temp"]
 fill = "surface_variant"
 padding = 6.0
 opacity = 0.8

--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -106,9 +106,9 @@ shadow = false
 capsule = true
 capsule_fill = "surface_variant"
 capsule_opacity = 0.8
-start = ["workspaces", "group:net-status"]
-center = ["tray"]
-end = ["media", "group:sys-status", "volume", "clock", "notifications", "clipboard", "session"]
+start = ["workspaces", "tray"]
+center = ["clock", "volume"]
+end = ["media", "group:net-status", "group:sys-status", "notifications", "clipboard", "session"]
 
 [[bar.main.capsule_group]]
 id = "net-status"

--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -106,13 +106,20 @@ shadow = false
 capsule = true
 capsule_fill = "surface_variant"
 capsule_opacity = 0.8
-start = ["workspaces"]
+start = ["workspaces", "group:net-status"]
 center = ["tray"]
-end = ["media", "group:sys-status", "volume", "battery", "clock", "notifications", "clipboard", "session"]
+end = ["media", "group:sys-status", "volume", "clock", "notifications", "clipboard", "session"]
+
+[[bar.main.capsule_group]]
+id = "net-status"
+members = ["net-down", "net-up"]
+fill = "surface_variant"
+padding = 6.0
+opacity = 0.8
 
 [[bar.main.capsule_group]]
 id = "sys-status"
-members = ["net-down", "net-up", "cpu", "ram", "temp"]
+members = ["cpu", "ram", "temp", "battery"]
 fill = "surface_variant"
 padding = 6.0
 opacity = 0.8


### PR DESCRIPTION
## Summary
- move tray to the start lane and place clock plus volume in the center lane
- add a network status capsule group for download/upload in the end lane
- group CPU, RAM percentage, CPU temperature, and battery into one end-lane status capsule
- make the Noctalia bar background square by setting radius to 0

## Verification
- noctalia config validate /home/collie/.local/share/chezmoi/home/dot_config/noctalia/config.toml
- chezmoi diff --source /home/collie/.local/share/chezmoi --dry-run