### PR TITLE
chore: use fish for opencode shell

### DIFF
--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "shell": "fish",
   "plugin": [
     "@bybrawe/opencode-loop@0.5.1",
     "@khalilgharbaoui/opencode-claude-code-plugin@latest"


### PR DESCRIPTION
## Summary
- Configure OpenCode's default shell as fish so the terminal and proxied bash tool calls run through fish.

## Validation
- chezmoi execute-template < home/dot_config/opencode/opencode.json.tmpl
- node JSON.parse validation for home/dot_config/opencode/opencode.json.tmpl
- chezmoi diff --source /home/collie/.local/share/chezmoi -- /home/collie/.config/opencode/opencode.json
- OPENCODE_CONFIG_CONTENT="{
  "$schema": "https://opencode.ai/config.json",
  "shell": "fish",
  "plugin": [
    "@bybrawe/opencode-loop@0.5.1",
    "@khalilgharbaoui/opencode-claude-code-plugin@latest"
  ],
  "permission": {
    "bash": "allow",
    "edit": "allow",
    "task": "allow",
    "webfetch": "allow"
  },
  "provider": {
    "claude-code": {
      "options": {
        "proxyTools": [
          "Bash",
          "Edit",
          "Write",
          "WebFetch",
          "Task"
        ],
        "bridgeOpencodeMcp": true,
        "strictMcpConfig": false,
        "webSearch": "claude"
      }
    }
  },
  "mcp": {
    "context7": {
      "type": "local",
      "command": [
        "npx",
        "-y",
        "@upstash/context7-mcp"
      ],
      "enabled": true
    },
    "zhtw-mcp": {
      "type": "local",
      "command": [
        "/home/collie/.local/bin/zhtw-mcp"
      ],
      "enabled": true
    }
  },
  "instructions": [
    "/home/collie/.config/opencode/instructions/zh-tw.md"
  ]
}" opencode debug config