### PR TITLE
fix: serialize Homebrew bundle in macOS CI

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -46,6 +46,8 @@ jobs:
   macos:
     name: macos:latest
     runs-on: macos-latest
+    env:
+      HOMEBREW_BUNDLE_NO_JOBS: "1"
     steps:
       - run: brew install chezmoi
       - name: chezmoi init dotfiles


### PR DESCRIPTION
## Summary
- Disable Homebrew Bundle parallel jobs in the macOS CI job with `HOMEBREW_BUNDLE_NO_JOBS=1`.
- Keep `runs-on: macos-latest` unchanged.

## Why
- Homebrew Bundle parallel workers can race on non-blocking Cellar locks, e.g. `bear` vs `cmake`.
- This is a CI-only workaround and does not slow local `brew bundle install`.

## Verification
- `git diff --check`
- GitHub Actions push workflow will verify the macOS job.