### PR TITLE
fix: sync Hyprland portal environment

### DIFF
--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -80,6 +80,13 @@ local noctalia    = "noctalia msg"
 -------------------
 
 hl.on("hyprland.start", function()
+    -- Keep D-Bus/systemd-activated portals in the Hyprland session.
+    hl.exec_cmd(
+        "/usr/bin/sh -lc 'export XDG_CURRENT_DESKTOP=Hyprland; " ..
+        "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP && " ..
+        "systemctl --user restart xdg-desktop-portal-hyprland.service && " ..
+        "systemctl --user restart xdg-desktop-portal.service'"
+    )
     hl.exec_cmd("blueman-applet")
     hl.exec_cmd("fcitx5 -d")
     hl.exec_cmd("noctalia")


### PR DESCRIPTION
## Summary
- sync Hyprland Wayland desktop environment into D-Bus/systemd activation on startup
- restart Hyprland portal and xdg-desktop-portal so ScreenCast can be exposed with the corrected environment

## Verification
- git diff --check
- chezmoi --source /home/collie/.local/share/chezmoi execute-template --init < home/dot_config/hypr/hyprland.lua.tmpl | luac -p -

## Manual Test
- Re-login or restart Hyprland, then test Google Meet / Vesktop screen sharing