### PR TITLE
closed: no-op after review

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -8,7 +8,6 @@ concurrency:
 
 env:
   CHEZMOI_BRANCH: ${{ github.head_ref || github.ref_name }}
-  CHEZMOI_VERBOSE: 1
 
 jobs:
   linux:


### PR DESCRIPTION
Closed because removing `CHEZMOI_VERBOSE` is not wanted and is too trivial for this repo. I will reopen or replace only after finding a non-trivial, validated change.