### PR TITLE
chore: add Vesktop cache repair helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ Then `chezmoi apply`.
 - If Noctalia Greeter shows a black screen, switch to a TTY with `Ctrl+Alt+F2` and run `sudo systemctl disable --now greetd.service && sudo systemctl enable --now sddm.service`.
 - If TTY switching does not work, boot with `systemd.unit=multi-user.target` from GRUB, then run the same service switch.
 
+### Vesktop Vencord cache recovery
+
+- Arch-based installs include `vesktop-bin`, but Vencord runtime files under `~/.config/vesktop/sessionData/vencordFiles` are managed by Vesktop, not by chezmoi.
+- Vesktop only recreates that cache when required files are missing; it does not check the cached Vencord commit on every startup.
+- If `Vencord`, `Plugins`, or `Vesktop Settings` disappears from Discord settings, or screen sharing fails after the portal picker with `CAPTURE_FAILURE`, quit Vesktop completely and run `vesktop-repair-vencord-cache`.
+- The helper only renames the cache to a timestamped backup. It does not run automatically or overwrite files with a separate downloader, so Vesktop remains the single updater for its runtime files.
+
 ### macOS extras
 
 - [`aerospace`](https://github.com/nikitabobko/AeroSpace) — tiling WM.

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -70,6 +70,7 @@ packages:
       - ttf-jetbrains-mono-nerd
       - typst
       - unzip
+      - vesktop-bin
       - wireplumber
       - wget
       - xdg-desktop-portal-gtk

--- a/home/dot_local/bin/executable_vesktop-repair-vencord-cache
+++ b/home/dot_local/bin/executable_vesktop-repair-vencord-cache
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cache_dir="${VESKTOP_VENCORD_CACHE:-${XDG_CONFIG_HOME:-$HOME/.config}/vesktop/sessionData/vencordFiles}"
+
+if pgrep -u "$(id -u)" -f '[v]esktop/app.asar|[d]ev.vencord.Vesktop' >/dev/null; then
+  printf 'Vesktop is running. Quit Vesktop completely before repairing the Vencord cache.\n' >&2
+  exit 1
+fi
+
+if [[ ! -e "$cache_dir" ]]; then
+  printf 'No Vencord cache found at %s\n' "$cache_dir"
+  printf 'Start Vesktop to let it create a fresh cache.\n'
+  exit 0
+fi
+
+backup_dir="${cache_dir}.backup-$(date +%Y%m%d-%H%M%S)"
+mv "$cache_dir" "$backup_dir"
+
+printf 'Moved stale Vencord cache to %s\n' "$backup_dir"
+printf 'Start Vesktop to download fresh Vencord runtime files.\n'


### PR DESCRIPTION
## Summary
- Add `vesktop-bin` to the Arch-based package list.
- Add a manual `vesktop-repair-vencord-cache` helper that renames Vesktop's local Vencord runtime cache to a timestamped backup.
- Document when to use the helper for missing Vencord settings or screen share `CAPTURE_FAILURE`.

## Rationale
- Vesktop owns `~/.config/vesktop/sessionData/vencordFiles`; chezmoi should not manage or sync that runtime cache.
- Vesktop recreates the cache when required files are missing, but does not verify the cached Vencord commit on every startup.
- The helper is intentionally manual and does not download files, overwrite cache contents, or run during `chezmoi apply`, so Vesktop remains the single updater for its runtime files.

## Verification
- `bash -n home/dot_local/bin/executable_vesktop-repair-vencord-cache`
- `git diff --check`
- `chezmoi --source /home/collie/.local/share/chezmoi apply --dry-run --verbose`
- `shellcheck` unavailable locally; skipped