### PR TITLE
feat: add Ponytail OpenCode skills

### DIFF
--- a/home/.chezmoiexternal.toml.tmpl
+++ b/home/.chezmoiexternal.toml.tmpl
@@ -19,3 +19,38 @@ refreshPeriod = "168h"
 type = "file"
 url = "https://raw.githubusercontent.com/addyosmani/agent-skills/main/LICENSE"
 refreshPeriod = "168h"
+
+[".config/opencode/skills/ponytail/SKILL.md"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/skills/ponytail/SKILL.md"
+refreshPeriod = "168h"
+
+[".config/opencode/skills/ponytail-review/SKILL.md"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/skills/ponytail-review/SKILL.md"
+refreshPeriod = "168h"
+
+[".config/opencode/skills/ponytail-audit/SKILL.md"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/skills/ponytail-audit/SKILL.md"
+refreshPeriod = "168h"
+
+[".config/opencode/skills/ponytail-debt/SKILL.md"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/skills/ponytail-debt/SKILL.md"
+refreshPeriod = "168h"
+
+[".config/opencode/skills/ponytail-gain/SKILL.md"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/skills/ponytail-gain/SKILL.md"
+refreshPeriod = "168h"
+
+[".config/opencode/skills/ponytail-help/SKILL.md"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/skills/ponytail-help/SKILL.md"
+refreshPeriod = "168h"
+
+[".config/opencode/skills/LICENSE.5ei74R0-ponytail-skills"]
+type = "file"
+url = "https://raw.githubusercontent.com/5ei74R0/ponytail-skills/main/LICENSE"
+refreshPeriod = "168h"


### PR DESCRIPTION
## Summary
- add prompt-only Ponytail skills from `5ei74R0/ponytail-skills` into `~/.config/opencode/skills`
- install each `SKILL.md` as a chezmoi external file, matching the existing external-file convention and avoiding another archive table targeting the same directory
- include the Ponytail skills-only fork license beside the existing agent-skills license

## Source reviewed
- `5ei74R0/ponytail-skills` says it is a skills-only fork that keeps Ponytail skill prompts and removes runtime code
- included skills: `ponytail`, `ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`
- intentionally not included: lifecycle hooks, local Node runtime, MCP server, OpenCode runtime plugin, workflows, npm metadata, benchmark runners

## Verification
- fetched upstream README and each referenced `skills/*/SKILL.md`
- compared branch against `master`: 1 file changed, only `.chezmoiexternal.toml.tmpl`
- no package/runtime/hook changes