### PR TITLE
closed: keep workflow verbosity

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -8,7 +8,6 @@ concurrency:
 
 env:
   CHEZMOI_BRANCH: ${{ github.head_ref || github.ref_name }}
-  CHEZMOI_VERBOSE: 1
 
 jobs:
   linux:


### PR DESCRIPTION
Closed. The workflow verbosity setting is intentional and should stay for debugging.