### PR TITLE
fix: use -y for brew upgrade alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Then `chezmoi apply`.
 | Alias | Expands to |
 |---|---|
 | `vi` | `nvim` (when nvim is installed) |
-| `buu` | `brew update && brew upgrade --no-ask && fisher update` (macOS only) |
+| `buu` | `brew update && brew upgrade -y && fisher update` (macOS only) |
 
 ## Tools
 

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -11,8 +11,9 @@ end
 # Homebrew environment
 set -gx HOMEBREW_NO_AUTO_UPDATE 1
 set -gx HOMEBREW_NO_ENV_HINTS 1
+set -gx HOMEBREW_NO_ASK 1
 
-alias buu "brew update && brew upgrade --no-ask && fisher update"
+alias buu "brew update && brew upgrade -y && fisher update"
 
 fish_add_path /opt/homebrew/bin
 /opt/homebrew/bin/brew shellenv | source

--- a/home/dot_config/fish/config.fish.tmpl
+++ b/home/dot_config/fish/config.fish.tmpl
@@ -11,7 +11,6 @@ end
 # Homebrew environment
 set -gx HOMEBREW_NO_AUTO_UPDATE 1
 set -gx HOMEBREW_NO_ENV_HINTS 1
-set -gx HOMEBREW_NO_ASK 1
 
 alias buu "brew update && brew upgrade -y && fisher update"
 


### PR DESCRIPTION
## Summary
- update the macOS fish `buu` alias to call `brew upgrade -y`
- keep prompt suppression scoped to the alias instead of setting `HOMEBREW_NO_ASK` globally
- sync the README alias documentation

## Verification
- `chezmoi execute-template < home/dot_config/fish/config.fish.tmpl | fish -n`
- `git diff --check`