### PR TITLE
fix: correct Noctalia widget monitor layout

### DIFF
--- a/home/dot_config/noctalia/20-widgets.generated.toml.tmpl
+++ b/home/dot_config/noctalia/20-widgets.generated.toml.tmpl
@@ -9,14 +9,8 @@ Keep source portable by deriving those values from monitor roles and ratios.
 {{- $center := index $outputs 1 -}}
 {{- $right := index $outputs 2 -}}
 {{- $centerName := index $center "name" -}}
-{{- $centerTransform := printf "%v" (index $center "transform") -}}
-{{- $centerRotated := or (eq $centerTransform "1") (eq $centerTransform "3") (eq $centerTransform "5") (eq $centerTransform "7") -}}
 {{- $centerWidth := divf (index $center "width") (index $center "scale") -}}
 {{- $centerHeight := divf (index $center "height") (index $center "scale") -}}
-{{- if $centerRotated -}}
-{{- $centerWidth = divf (index $center "height") (index $center "scale") -}}
-{{- $centerHeight = divf (index $center "width") (index $center "scale") -}}
-{{- end -}}
 {{- $rightName := index $right "name" -}}
 {{- $rightTransform := printf "%v" (index $right "transform") -}}
 {{- $rightRotated := or (eq $rightTransform "1") (eq $rightTransform "3") (eq $rightTransform "5") (eq $rightTransform "7") -}}
@@ -94,14 +88,8 @@ visible = true
 
 {{ range $monitor := $outputs }}
 {{- $monitorName := index $monitor "name" -}}
-{{- $monitorTransform := printf "%v" (index $monitor "transform") -}}
-{{- $monitorRotated := or (eq $monitorTransform "1") (eq $monitorTransform "3") (eq $monitorTransform "5") (eq $monitorTransform "7") -}}
 {{- $monitorWidth := divf (index $monitor "width") (index $monitor "scale") -}}
 {{- $monitorHeight := divf (index $monitor "height") (index $monitor "scale") -}}
-{{- if $monitorRotated -}}
-{{- $monitorWidth = divf (index $monitor "height") (index $monitor "scale") -}}
-{{- $monitorHeight = divf (index $monitor "width") (index $monitor "scale") -}}
-{{- end -}}
 [lockscreen_widgets.widget."lockscreen-login-box@{{ $monitorName }}"]
 type = "login_box"
 output = "{{ $monitorName }}"

--- a/home/dot_config/noctalia/20-widgets.generated.toml.tmpl
+++ b/home/dot_config/noctalia/20-widgets.generated.toml.tmpl
@@ -4,16 +4,28 @@ Keep source portable by deriving those values from monitor roles and ratios.
 */ -}}
 {{- $hyprland := and (eq .chezmoi.os "linux") (lookPath "hyprctl") (env "HYPRLAND_INSTANCE_SIGNATURE") (env "XDG_RUNTIME_DIR") -}}
 {{- if $hyprland -}}
-{{- $outputs := (output "hyprctl" "monitors" "-j" | fromJson | jq "map(select(((.disabled // false) == false) and ((.mirrorOf // \"none\") == \"none\"))) | sort_by(.x)" | first) -}}
+{{- $outputs := (output "hyprctl" "monitors" "-j" | jq "fromjson | map(select((.disabled != true) and ((.mirrorOf // \"none\") == \"none\"))) | sort_by(.x)" | first) -}}
 {{- if ge (len $outputs) 3 -}}
 {{- $center := index $outputs 1 -}}
 {{- $right := index $outputs 2 -}}
 {{- $centerName := index $center "name" -}}
+{{- $centerTransform := printf "%v" (index $center "transform") -}}
+{{- $centerRotated := or (eq $centerTransform "1") (eq $centerTransform "3") (eq $centerTransform "5") (eq $centerTransform "7") -}}
 {{- $centerWidth := divf (index $center "width") (index $center "scale") -}}
 {{- $centerHeight := divf (index $center "height") (index $center "scale") -}}
+{{- if $centerRotated -}}
+{{- $centerWidth = divf (index $center "height") (index $center "scale") -}}
+{{- $centerHeight = divf (index $center "width") (index $center "scale") -}}
+{{- end -}}
 {{- $rightName := index $right "name" -}}
+{{- $rightTransform := printf "%v" (index $right "transform") -}}
+{{- $rightRotated := or (eq $rightTransform "1") (eq $rightTransform "3") (eq $rightTransform "5") (eq $rightTransform "7") -}}
 {{- $rightWidth := divf (index $right "width") (index $right "scale") -}}
 {{- $rightHeight := divf (index $right "height") (index $right "scale") -}}
+{{- if $rightRotated -}}
+{{- $rightWidth = divf (index $right "height") (index $right "scale") -}}
+{{- $rightHeight = divf (index $right "width") (index $right "scale") -}}
+{{- end -}}
 {{- $lockClockHeightRatio := 0.1666666667 -}}
 {{- $lockLoginHeightRatio := divf 70.0 1152.0 -}}
 {{- $lockGroupGapRatio := divf 40.0 1152.0 -}}
@@ -82,8 +94,14 @@ visible = true
 
 {{ range $monitor := $outputs }}
 {{- $monitorName := index $monitor "name" -}}
+{{- $monitorTransform := printf "%v" (index $monitor "transform") -}}
+{{- $monitorRotated := or (eq $monitorTransform "1") (eq $monitorTransform "3") (eq $monitorTransform "5") (eq $monitorTransform "7") -}}
 {{- $monitorWidth := divf (index $monitor "width") (index $monitor "scale") -}}
 {{- $monitorHeight := divf (index $monitor "height") (index $monitor "scale") -}}
+{{- if $monitorRotated -}}
+{{- $monitorWidth = divf (index $monitor "height") (index $monitor "scale") -}}
+{{- $monitorHeight = divf (index $monitor "width") (index $monitor "scale") -}}
+{{- end -}}
 [lockscreen_widgets.widget."lockscreen-login-box@{{ $monitorName }}"]
 type = "login_box"
 output = "{{ $monitorName }}"


### PR DESCRIPTION
## Summary
- parse hyprctl monitor JSON inside jq so x-position sorting actually applies
- account for rotated outputs when deriving desktop widget coordinates on the right monitor
- keep lockscreen widget coordinates in Noctalia's expected unrotated reference space
- clear local stale Noctalia lockscreen state so config fallback is active on this machine

## Verification
- chezmoi execute-template < home/dot_config/noctalia/20-widgets.generated.toml.tmpl
- chezmoi apply -v /home/collie/.config/noctalia/20-widgets.generated.toml
- noctalia config validate /home/collie/.config/noctalia
- noctalia config validate /home/collie/.config/noctalia/20-widgets.generated.toml
- noctalia config validate
- chezmoi diff /home/collie/.config/noctalia/20-widgets.generated.toml
- restarted noctalia and confirmed it is responding with noctalia msg status

## Notes
- Desktop widget idle/media visibility settings are intentionally unchanged: show_when_idle remains false, hide_when_no_media remains true.
- A full chezmoi apply dry-run shows unrelated destination drift under ~/.config/opencode/skills; this PR does not touch those files.