### PR TITLE
Keep Markdown preview tabs open across buffers

### DIFF
--- a/home/dot_config/nvim/lua/plugins/markdown-preview.lua
+++ b/home/dot_config/nvim/lua/plugins/markdown-preview.lua
@@ -1,0 +1,9 @@
+return {
+  {
+    "iamcco/markdown-preview.nvim",
+    init = function()
+      vim.g.mkdp_auto_close = 0
+      vim.g.mkdp_combine_preview = 0
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
- disable markdown-preview.nvim auto-close when switching buffers
- keep combine preview disabled so each Markdown file can use its own browser tab

## Verification
- luac -p home/dot_config/nvim/lua/plugins/markdown-preview.lua
- XDG_CONFIG_HOME=/home/collie/.local/share/chezmoi/home/dot_config nvim --headless "+lua assert(vim.g.mkdp_auto_close == 0, 'mkdp_auto_close not disabled'); assert(vim.g.mkdp_combine_preview == 0, 'mkdp_combine_preview not disabled')" "+qa"