### PR TITLE
fix: stop subagents from recursive dispatch

### DIFF
--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -10,7 +10,6 @@
   "permission": {
     "bash": "allow",
     "edit": "allow",
-    "task": "allow",
     "webfetch": "allow"
   },
   "provider": {


### PR DESCRIPTION
## Summary
- remove the global OpenCode task permission
- restore the default leaf-agent behavior: subagents cannot dispatch further subagents

## Validation
- chezmoi template render parsed as JSON
- git diff --check