### PR TITLE
feat(noctalia): sync portable shell preferences

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -29,6 +29,7 @@ packages:
       - glab
       - go
       - gping
+      - gpu-screen-recorder
       - hugo
       - hyprland
       - keepassxc

--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -5,13 +5,26 @@ polkit_agent = false
 clipboard_enabled = true
 clipboard_history_max_entries = 100
 clipboard_auto_paste = "auto"
+screen_time_enabled = true
 
 [shell.panel]
-launcher_placement = "centered"
-clipboard_placement = "centered"
+launcher_placement = "floating"
+launcher_position = "center"
+clipboard_placement = "floating"
+clipboard_position = "center"
 control_center_placement = "attached"
 wallpaper_placement = "attached"
 session_placement = "attached"
+
+[shell.animation]
+speed = 1.8
+
+[shell.screen_corners]
+enabled = true
+size = 13
+
+[shell.shadow]
+direction = "center"
 
 [shell.screenshot]
 save_to_file = false
@@ -21,7 +34,7 @@ pipe_to_command = false
 
 [wallpaper]
 enabled = true
-fill_mode = "crop"
+fill_mode = "stretch"
 directory = "~/.config/wallpapers"
 transition_on_startup = false
 
@@ -63,6 +76,7 @@ background_opacity = 0.97
 position = "top_center"
 orientation = "horizontal"
 scale = 1.0
+background_opacity = 0.14
 
 [lockscreen]
 enabled = true
@@ -72,6 +86,8 @@ tint_intensity = 0.3
 
 [system.monitor]
 enabled = true
+cpu_temp_activity_threshold = 70
+cpu_temp_critical_threshold = 100
 
 [weather]
 enabled = true
@@ -107,6 +123,9 @@ left = ["left"]
 right = ["right"]
 up = ["up"]
 down = ["down"]
+
+[plugins]
+enabled = ["noctalia/screen_recorder", "noctalia/timer"]
 
 [bar]
 order = ["main"]
@@ -195,4 +214,11 @@ hide_when_no_unread = false
 drawer = false
 
 [dock]
-enabled = false
+enabled = true
+active_monitor_only = true
+auto_hide = true
+background_opacity = 0.75
+icon_size = 33
+magnification_scale = 1.8
+reserve_space = false
+shadow = false


### PR DESCRIPTION
## 目的

讓 Noctalia 的常用功能以 chezmoi 的 declarative config 跨機器重現，而不是依賴 GUI 寫入的 ~/.local/state/noctalia/settings.toml。後者優先權較高，且混有暫態與私密資料。

## 這個 PR 會重現

- 螢幕使用時間功能開關。
- Dock：啟用、auto-hide、圖示大小、放大倍率、透明度與不保留空間。
- 螢幕角落、動畫速度、陰影方向、OSD 透明度。
- CPU 溫度 activity/critical 門檻。
- 全域桌布填滿模式 stretch；既有的預設桌布與天氣 Taipei 設定維持 declarative。
- Noctalia Screen Recorder 與 Timer plugins。
- Arch/CachyOS 的 gpu-screen-recorder，供 Screen Recorder plugin 使用。

## 使用方式與限制

- 新機器執行 chezmoi apply 後，Noctalia 會讀取上述設定；如果曾經透過 GUI 設定相同項目，~/.local/state/noctalia/settings.toml 仍會覆蓋 dotfiles，需移除相應 override。
- Screen Recorder 仍需要已存在的 xdg-desktop-portal-hyprland；錄影預設輸出目錄由 plugin 使用 ~/Videos/Recordings。
- 每個輸出 connector（例如 DP-2）各自選的桌布不會同步，避免把公司螢幕名稱套用到其他硬體。

## 刻意不同步

- 螢幕使用歷史、clipboard/notification history、recently-used 與 usage counts。
- GUI state 的其他暫態資料與硬體綁定資料。
- BongoCat plugin：不在這次需求內。

## 後續範圍（本 PR 未處理）

- Greeter 的 auto-sync/polkit 流程。
- 需在有效 Hyprland session 與至少三個輸出下產生的 desktop/lockscreen widgets。
- Ubuntu/Debian/Mint 尚未安裝 Noctalia/greetd，因此不屬於完整 Shell/Greeter 支援。

## 驗證

- noctalia config validate home/dot_config/noctalia。
- 以空的 Noctalia state 目錄匯出有效設定，確認所有跨機器偏好存在。
- GitHub Actions：Arch、CachyOS、Ubuntu、macOS。