### PR TITLE
chore: stop installing Cursor

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -11,7 +11,6 @@ packages:
       - catppuccin-cursors-mocha
       - clang
       - curl
-      - cursor-bin
       - eza
       - fastfetch
       - fd

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -16,7 +16,6 @@ Library/**
 .config/BraveSoftware/**
 .config/brave-origin-flags.conf
 .config/code-flags.conf
-.config/cursor-flags.conf
 .config/electron-flags.conf
 .config/environment.d
 .config/environment.d/**

--- a/home/.chezmoiremove
+++ b/home/.chezmoiremove
@@ -1,4 +1,5 @@
 .config/hypr/hyprland.conf
+.config/cursor-flags.conf
 {{ if eq .chezmoi.os "linux" }}
 .config/hypr/hypridle.conf
 .config/hypr/hyprlock.conf

--- a/home/dot_config/cursor-flags.conf
+++ b/home/dot_config/cursor-flags.conf
@@ -1,4 +1,0 @@
---ozone-platform=wayland
---enable-features=WaylandWindowDecorations,UseOzonePlatform
---enable-wayland-ime
-


### PR DESCRIPTION
## 變更

- 從 Arch/CachyOS 的預設套件清單移除 cursor-bin。
- 刪除 Cursor editor 專屬的 cursor-flags.conf。
- chezmoi apply 會移除既有機器的 ~/.config/cursor-flags.conf，避免留下無主設定。

## 保留項目

這不影響 Catppuccin 指標主題、Hyprland 的 HYPRCURSOR/XCURSOR 設定、終端文字游標或 Neovim cursor plugin。

## 驗證

- Rendered package installer 不含 cursor-bin。
- chezmoi apply dry-run 顯示會刪除舊的 Cursor flags。
- git diff check 通過。