### PR TITLE
fix: restore Noctalia idle and greeter sync

### DIFF
--- a/home/.chezmoiscripts/run_onchange_after_4-configure-greetd-noctalia.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_4-configure-greetd-noctalia.sh.tmpl
@@ -15,6 +15,35 @@ enable_sddm_fallback() {
   fi
 }
 
+setup_script="/usr/share/noctalia-greeter/setup_greeter_system.sh"
+greeter_state_dir="/var/lib/noctalia-greeter"
+pacman_hook_dir="/etc/pacman.d/hooks"
+
+harden_greeter_state_dir() {
+  sudo install -d -o root -g root -m 0755 "$greeter_state_dir"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "${tmpdir}/99-noctalia-greeter-state-dir.hook" <<'PACMAN_HOOK'
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = noctalia-greeter
+
+[Action]
+Description = Protecting Noctalia Greeter sync directory...
+When = PostTransaction
+Exec = /usr/bin/install -d -o root -g root -m 0755 /var/lib/noctalia-greeter
+PACMAN_HOOK
+sudo install -d -o root -g root -m 0755 "$pacman_hook_dir"
+sudo install -o root -g root -m 0644 \
+  "${tmpdir}/99-noctalia-greeter-state-dir.hook" \
+  "${pacman_hook_dir}/99-noctalia-greeter-state-dir.hook"
+harden_greeter_state_dir
+
 if ! command -v noctalia-greeter-session >/dev/null 2>&1; then
   echo -e "${YELLOW}Warning: noctalia-greeter-session not found; keeping SDDM enabled.${NC}"
   enable_sddm_fallback
@@ -28,8 +57,6 @@ if ! getent passwd greeter >/dev/null 2>&1; then
 fi
 
 session_bin="$(command -v noctalia-greeter-session)"
-setup_script="/usr/share/noctalia-greeter/setup_greeter_system.sh"
-greeter_state_dir="/var/lib/noctalia-greeter"
 
 if [ ! -x "$setup_script" ]; then
   echo -e "${YELLOW}Warning: ${setup_script} not found; keeping SDDM enabled.${NC}"
@@ -38,15 +65,14 @@ if [ ! -x "$setup_script" ]; then
 fi
 
 if ! sudo env GREETER_USER=greeter "$setup_script"; then
+  harden_greeter_state_dir
   echo -e "${YELLOW}Warning: Noctalia Greeter setup failed; keeping SDDM enabled.${NC}"
   enable_sddm_fallback
   exit 0
 fi
+harden_greeter_state_dir
 
 sudo install -d -o root -g root -m 0755 /etc/greetd
-
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
 
 noctalia_msg() {
   if command -v timeout >/dev/null 2>&1; then
@@ -56,7 +82,6 @@ noctalia_msg() {
   fi
 }
 
-sudo install -d -o greeter -g greeter -m 0755 "$greeter_state_dir"
 cat > "${tmpdir}/greeter.toml" <<GREETER_TOML
 # noctalia-greeter greeter.toml
 # Managed by chezmoi. Wallpaper/colors are synced by: noctalia msg greeter-sync

--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -1,11 +1,14 @@
 [shell]
 font_family = "JetBrainsMono Nerd Font"
 telemetry_enabled = false
-polkit_agent = false
+polkit_agent = true
 clipboard_enabled = true
 clipboard_history_max_entries = 100
 clipboard_auto_paste = "auto"
 screen_time_enabled = true
+
+[shell.greeter_sync]
+auto_sync = true
 
 [shell.panel]
 launcher_placement = "floating"
@@ -108,13 +111,12 @@ pre_action_fade_seconds = 2.0
 [idle.behavior.lock]
 enabled = true
 timeout = 300
-command = "noctalia:session lock"
+action = "lock"
 
 [idle.behavior.screen-off]
 enabled = true
 timeout = 600
-command = "noctalia:dpms-off"
-resume_command = "noctalia:dpms-on"
+action = "screen_off"
 
 [keybinds]
 validate = ["return", "kp_enter"]


### PR DESCRIPTION
## Summary
- replace removed `noctalia:` idle shorthand with native `lock` and `screen_off` actions
- enable the Noctalia polkit agent and automatic greeter appearance sync
- protect privileged greeter sync targets with a root-owned state directory and an ALPM hook that reapplies ownership after package upgrades

## Why
Noctalia v5 beta.3 removed the internal command shorthand, causing the fade overlay to complete while lock and DPMS commands silently failed. Greeter appearance sync was also disabled and could not request graphical authorization.

The greeter setup package owns `/var/lib/noctalia-greeter` as the low-privilege greeter account while a root helper overwrites fixed files there. Keeping the parent root-owned prevents path substitution; `greeter.toml` and logs remain greeter-owned and writable.

## Verification
- `noctalia config validate` passes with three unrelated existing widget warnings
- effective config exports `action = "lock"`, `action = "screen_off"`, and `auto_sync = true`
- `chezmoi verify`, rendered script `bash -n`, and `git diff --check` pass
- live polkit authorization and greeter appearance sync update the root-owned manifest and wallpaper successfully
- greeter can write `greeter.toml` but cannot write its parent directory
- independent security re-review approved the final diff