### PR TITLE
chore: remove Addy agent skills

### DIFF
--- a/home/.chezmoidata/ai.yaml
+++ b/home/.chezmoidata/ai.yaml
@@ -21,10 +21,7 @@ ai:
       - "@dietrichgebert/ponytail"
 
   skills:
-    git:
-      - id: addyosmani-agent-skills
-        source: https://github.com/addyosmani/agent-skills.git
-        path: skills
+    git: []
     local:
       - .local/share/ai-skills
     destinations:


### PR DESCRIPTION
## Summary
- Stop syncing addyosmani/agent-skills from chezmoi.
- Keep the empty git source list because the sync template reads the key.
- Keep respond-structured, Ponytail, and the OpenCode Claude bridge plugin.

## Verification
- chezmoi verify
- Rendered sync script passes bash -n and contains no Addy source.
- Claude, Codex, and OpenCode configurations validate.
- Ponytail remains enabled in Claude and Codex and configured in OpenCode.