### PR TITLE
Remove office Hyprland monitor rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ chezmoi init --apply collieiscute -v
 
 ### Hyprland
 
-- 3 desc-keyed Lua `hl.monitor(...)` rules plus a fallback that selects the highest resolution and refresh rate available at that resolution.
+- Desc-keyed Lua `hl.monitor(...)` overrides plus a fallback that selects the highest resolution and refresh rate available at that resolution.
 - Cursor: Catppuccin Mocha Teal (Hyprcursor) with Catppuccin Mocha Green as XCursor fallback.
 - Electron / fcitx5 / GTK theming env vars set centrally.
 - Noctalia v5 owns the desktop shell layer (bar, launcher, notifications, wallpaper, lock screen, idle, screenshots, clipboard).

--- a/README.md
+++ b/README.md
@@ -31,19 +31,6 @@ chezmoi init --apply collieiscute -v
 - Theme files for kitty and alacritty are pulled from the upstream `catppuccin/*` repos via [`.chezmoiexternal.toml.tmpl`](home/.chezmoiexternal.toml.tmpl) with `refreshPeriod = "168h"`; Ghostty uses its built-in Catppuccin theme.
 - Font: **JetBrainsMono Nerd Font** across every terminal / bar / lock screen.
 
-### Per-host config switch
-
-Two Hyprland machines (home + office) share one config but pin different monitors to ws1/2/3. Office hosts get desc-keyed workspace rules; home hosts use Hyprland's default per-monitor assignment (which already gives 1/2/3) — hand-rolled rules would otherwise reserve those slots even when the matching monitor isn't connected (see `hyprland.lua.tmpl` head comment for the underlying bug).
-
-To mark a machine as office: edit `~/.config/chezmoi/chezmoi.toml` →
-
-```toml
-[data]
-  location = "office"
-```
-
-Then `chezmoi apply`.
-
 ### chezmoi quirks I keep tripping over (that this repo handles)
 
 - `run_onchange_*` scripts only re-run when their **rendered** content changes. Manifest files (`fish_plugins`, `Brewfile`) that aren't templated into the script bodies don't trigger reruns. Both are pinned via embedded sha256 hash comments — see `run_onchange_after_1-setup-fish-and-its-plugins.sh.tmpl` and `install-packages_darwin.tmpl`.
@@ -66,13 +53,13 @@ Then `chezmoi apply`.
 
 ### Hyprland
 
-- 6 Lua `hl.monitor(...)` rules (3 home + 3 office) — desc-keyed so the right machine picks the right monitors automatically.
+- 3 desc-keyed Lua `hl.monitor(...)` rules plus a fallback that selects the highest resolution and refresh rate available at that resolution.
 - Cursor: Catppuccin Mocha Teal (Hyprcursor) with Catppuccin Mocha Green as XCursor fallback.
 - Electron / fcitx5 / GTK theming env vars set centrally.
 - Noctalia v5 owns the desktop shell layer (bar, launcher, notifications, wallpaper, lock screen, idle, screenshots, clipboard).
 - Wallpapers are deployed by chezmoi to `~/.config/wallpapers`; Noctalia reads that path directly.
 - Noctalia is the Linux wallpaper/theme owner. App theme integrations should write generated theme files and reload apps, not mutate chezmoi-managed main config files.
-- Noctalia desktop/lockscreen widget placement is generated from monitor roles and ratios in `20-widgets.generated.toml.tmpl`; run `chezmoi apply` after moving between home/office monitor layouts.
+- Noctalia desktop/lockscreen widget placement is generated from monitor roles and ratios in `20-widgets.generated.toml.tmpl`; run `chezmoi apply` after changing the monitor layout.
 - If widgets are edited in Noctalia's GUI, remove `[desktop_widgets]` and `[lockscreen_widgets]` from `~/.local/state/noctalia/settings.toml` or fold the new ratios back into the template; state overrides win over declarative config.
 
 ## Keymappings

--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -43,7 +43,7 @@ hl.monitor({
 
 -- Dell portrait monitor - 90 degrees clockwise
 hl.monitor({
-    output    = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",
+    output    = "desc:Dell Inc. DELL U2412M",
     mode      = "highres",
     position  = "auto",
     transform = 1,

--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -6,10 +6,10 @@
 ---- MONITORS ----
 ------------------
 
--- Default fallback - will be overridden when a known output below matches.
+-- Default fallback - highest resolution and refresh rate available at that resolution.
 hl.monitor({
     output   = "",
-    mode     = "highres@highrr",
+    mode     = "highres",
     position = "auto",
 })
 
@@ -40,31 +40,6 @@ hl.monitor({
     position = "auto-center-right",
     scale    = 1.0,
 })
-
--- Office: explicit coordinates. Hyprland processes auto-* monitors in
--- connection order (m_monitors iteration in CCompositor::arrangeMonitors),
--- and the first-processed one always lands at (0,0) regardless of direction.
--- Dell connects as ID 0, so auto-right was a no-op. Hardcoding sidesteps that.
-hl.monitor({
-    output   = "desc:BNQ BenQ GC2870 51J06421019",
-    mode     = "1920x1080@60",
-    position = "0x0",
-})
-
-hl.monitor({
-    output   = "desc:BNQ BenQ GW2790",
-    mode     = "1920x1080@60",
-    position = "1920x0",
-})
-
-hl.monitor({
-    output    = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",
-    mode      = "1920x1080@60",
-    position  = "3840x0",
-    scale     = 1.25,
-    transform = 1,
-})
-
 
 ---------------------
 ---- MY PROGRAMS ----
@@ -309,18 +284,6 @@ hl.bind("XF86AudioPrev",  hl.dsp.exec_cmd(noctalia .. " media previous"), { lock
 ----------------------------------
 ---- WINDOWS AND WORKSPACES ----
 ----------------------------------
-
--- Office: pin ws1/2/3 to BenQ/BenQ/Dell (left-to-right). Only emit when this
--- is the office host: a desc-keyed rule would otherwise reserve the slot at
--- home (Hyprland's findAvailableDefaultWS() compares the rule string against
--- the connected monitor's name without resolving desc:), pushing home
--- monitors to ws4/5/6. With no rules at home, Hyprland's default per-monitor
--- workspace assignment gives 1/2/3.
-{{- if eq (index . "location") "office" }}
-hl.workspace_rule({ workspace = 1, monitor = "desc:BNQ BenQ GC2870 51J06421019",         default = true })
-hl.workspace_rule({ workspace = 2, monitor = "desc:BNQ BenQ GW2790",                     default = true })
-hl.workspace_rule({ workspace = 3, monitor = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",  default = true })
-{{- end }}
 
 -- Ignore maximize requests from apps. You'll probably like this.
 hl.window_rule({

--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -41,12 +41,12 @@ hl.monitor({
     scale    = 1.0,
 })
 
--- Dell portrait monitor - 90 degrees counterclockwise
+-- Dell portrait monitor - 90 degrees clockwise
 hl.monitor({
     output    = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",
     mode      = "highres",
     position  = "auto",
-    transform = 3,
+    transform = 1,
 })
 
 ---------------------

--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -41,6 +41,14 @@ hl.monitor({
     scale    = 1.0,
 })
 
+-- Dell portrait monitor - 90 degrees counterclockwise
+hl.monitor({
+    output    = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",
+    mode      = "highres",
+    position  = "auto",
+    transform = 3,
+})
+
 ---------------------
 ---- MY PROGRAMS ----
 ---------------------


### PR DESCRIPTION
## Summary
- remove unused office monitor/workspace rules and the `location` switch
- use `highres` for fallback monitors
- update the portrait Dell rule for the U2412M

## Verification
- Hyprland and chezmoi validation passed
- Dell U2412M: `1920x1200@59.95`, `transform: 1`
- Linux and macOS CI passed