### PR TITLE
Set Nautilus as default file manager

### DIFF
--- a/home/dot_config/mimeapps.list
+++ b/home/dot_config/mimeapps.list
@@ -1,4 +1,5 @@
 [Default Applications]
+inode/directory=org.gnome.Nautilus.desktop
 x-scheme-handler/discord=vesktop.desktop
 x-scheme-handler/sgnl=signal.desktop
 x-scheme-handler/signalcaptcha=signal.desktop


### PR DESCRIPTION
## Summary
- set `org.gnome.Nautilus.desktop` as the XDG default for `inode/directory`
- keep `wo` on the system opener so files and URLs retain their existing defaults

## Research
- followed the Freedesktop MIME Applications specification and ArchWiki recommendation to use `[Default Applications]` in `~/.config/mimeapps.list`
- checked 50 public directory-handler configs and 50 unique Nautilus configs; the current Nautilus desktop ID is the established setting

## Verification
- isolated Chezmoi apply: `xdg-mime query default inode/directory` returned `org.gnome.Nautilus.desktop`
- local XDG and GIO defaults both resolve directories to Nautilus
- Arch Linux, CachyOS, Ubuntu, and macOS CI passed