### PR TITLE
Use Hyprland's default mouse refocus

### DIFF
--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -203,7 +203,6 @@ hl.config({
 
 hl.config({
     input = {
-        mouse_refocus  = false,
         natural_scroll = true,
         accel_profile  = "flat",
         touchpad = {


### PR DESCRIPTION
## Summary
- remove the explicit `mouse_refocus = false` override
- let Hyprland use its default `true` behavior

## Verification
- `git diff --check` passed
- rendered Hyprland Lua template passed `luac -p`