### PR TITLE
Restore Dell P2214H monitor settings

### DIFF
--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -41,11 +41,12 @@ hl.monitor({
     scale    = 1.0,
 })
 
--- Dell portrait monitor - 90 degrees clockwise
+-- Dell P2214H portrait monitor - 90 degrees clockwise
 hl.monitor({
-    output    = "desc:Dell Inc. DELL U2412M",
+    output    = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",
     mode      = "highres",
     position  = "auto",
+    scale     = 1.25,
     transform = 1,
 })
 


### PR DESCRIPTION
## Summary
- retarget the portrait Dell rule to the connected P2214H by its full EDID description
- restore the historical 1.25 scale while preserving clockwise rotation

## Verification
- rendered the chezmoi template and passed `luac -p`
- applied the config and reloaded Hyprland without config errors
- confirmed DP-4 runs at `1920x1080@60`, scale `1.25`, transform `1`
- `chezmoi verify` passed for the generated Hyprland config