### PR TITLE
Update Dell P2314H and Kitty cursor trail

### DIFF
--- a/home/dot_config/hypr/hyprland.lua.tmpl
+++ b/home/dot_config/hypr/hyprland.lua.tmpl
@@ -41,9 +41,9 @@ hl.monitor({
     scale    = 1.0,
 })
 
--- Dell P2214H portrait monitor - 90 degrees clockwise
+-- Dell P2314H portrait monitor - 90 degrees clockwise
 hl.monitor({
-    output    = "desc:Dell Inc. DELL P2214H 20C1Y64C5EEL",
+    output    = "desc:Dell Inc. DELL P2314H G9D5T61P768S",
     mode      = "highres",
     position  = "auto",
     scale     = 1.25,

--- a/home/dot_config/kitty/kitty.conf.tmpl
+++ b/home/dot_config/kitty/kitty.conf.tmpl
@@ -68,6 +68,7 @@ visual_bell_duration 0.0
 # ── Cursor ─────────────────────────────────────────────────────────
 cursor_shape     beam
 cursor_blink_interval 0
+cursor_trail     3
 
 # ── Mouse ──────────────────────────────────────────────────────────
 url_style        curly


### PR DESCRIPTION
## Summary
- retarget the portrait Dell rule from the retired P2214H to the connected P2314H by its full EDID description
- preserve the existing high-resolution mode, 1.25 scale, and clockwise rotation
- sync Kitty cursor trail animation with `cursor_trail 3`

## Verification
- rendered the Hyprland template and passed `luac -p`
- applied both configs and reloaded Hyprland without config errors
- confirmed DP-3 runs at `1920x1080@60`, scale `1.25`, transform `1`
- parsed Kitty config with `cursor_trail=3` and no bad lines
- `chezmoi verify` passed and both managed targets have no diff