### PR TITLE
feat(noctalia): show GPU and VRAM usage

### DIFF
--- a/home/dot_config/noctalia/config.toml
+++ b/home/dot_config/noctalia/config.toml
@@ -165,7 +165,7 @@ opacity = 0.3
 
 [[bar.main.capsule_group]]
 id = "sys-status"
-members = ["cpu", "ram", "temp", "battery"]
+members = ["cpu", "gpu", "ram", "vram", "temp", "battery"]
 fill = "surface_variant"
 padding = 3.0
 opacity = 0.3
@@ -193,6 +193,11 @@ type = "sysmon"
 stat = "cpu_usage"
 display = "text"
 
+[widget.gpu]
+type = "sysmon"
+stat = "gpu_usage"
+display = "text"
+
 [widget.temp]
 type = "sysmon"
 stat = "cpu_temp"
@@ -201,6 +206,11 @@ display = "text"
 [widget.ram]
 type = "sysmon"
 stat = "ram_pct"
+display = "text"
+
+[widget.vram]
+type = "sysmon"
+stat = "gpu_vram"
 display = "text"
 
 [widget.volume]


### PR DESCRIPTION
## Summary

- add GPU usage and VRAM percentage to the existing `sys-status` capsule group
- reuse Noctalia v5 native `sysmon` stats: `gpu_usage` and `gpu_vram`
- keep the existing text display and polling service; no scripts or dependencies added

## Research

- this repo targets Noctalia v5
- the installed package is v5.0.0-beta.7
- the matching upstream widget definition supports both stats and formats each as a percentage

## Verification

- `noctalia config validate home/dot_config/noctalia/config.toml`
- `git diff --check`
- `chezmoi diff --source /tmp/chezmoi-noctalia-gpu-vram --dry-run` could not complete locally because the existing generated monitor template requires an active Hyprland socket; the branch CI covers clean distro applies