### PR TITLE
refactor(ai): remove redundant agent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ AeroSpace restores the swapped root layouts and window states where possible; it
 - Build / dev: [`gnu-tar`](https://www.gnu.org/software/tar/), [`bear`](https://github.com/rizsotto/Bear), [`cmake`](https://cmake.org), [`mold`](https://github.com/rui314/mold), [`ninja`](https://ninja-build.org), [`llvm`](https://llvm.org), [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html), [`cppcheck`](https://cppcheck.sourceforge.io), [`uv`](https://github.com/astral-sh/uv).
 - Containers: macOS Apple silicon [`container`](https://github.com/apple/container) + third-party [`container-compose`](https://github.com/Mcrich23/Container-Compose); Linux [`podman`](https://podman.io).
 - Docs: [`hugo`](https://gohugo.io), [`typst`](https://typst.app), [`tldr`](https://tldr.sh).
-- Codex/OpenCode zh-TW linting: [`zhtw-mcp`](https://github.com/sysprog21/zhtw-mcp) is configured as a local MCP server at `~/.local/bin/zhtw-mcp`. Until upstream publishes releases, install it from source with `make install` so both agents can use the fixed binary path.
+- OpenCode zh-TW linting: [`zhtw-mcp`](https://github.com/sysprog21/zhtw-mcp) is configured as a local MCP server at `~/.local/bin/zhtw-mcp`. Until upstream publishes releases, install it from source with `make install` so OpenCode can use the fixed binary path.
 - OpenCode Claude Code plugin: [`@khalilgharbaoui/opencode-claude-code-plugin`](https://github.com/khalilgharbaoui/opencode-claude-code-plugin) is loaded through OpenCode's native npm plugin support; after changing the plugin list, run `chezmoi apply /home/collie/.config/opencode/opencode.json` and restart OpenCode.
 
 ### AI extensions
@@ -214,8 +214,8 @@ AeroSpace restores the swapped root layouts and window states where possible; it
 - [`home/.chezmoidata/ai.yaml`](home/.chezmoidata/ai.yaml) is the single inventory for plugins and marketplaces; add entries there without editing templates.
 - Claude Code and Codex update configured marketplace plugins with their native startup updaters.
 - OpenCode installs configured npm plugins when its generated cache is missing; remove that cache before startup to fetch newer versions.
-- Shared user skills live in `~/.agents/skills`, which Codex and OpenCode discover natively; Claude Code uses compatibility symlinks under `~/.claude/skills`.
-- `run_after_5-sync-ai-extensions.sh.tmpl` bootstraps missing Codex plugins and its `zhtw-mcp` registration.
+- Shared user skills live in `~/.agents/skills`, which Codex and OpenCode discover natively.
+- `run_after_5-sync-ai-extensions.sh.tmpl` bootstraps missing Codex plugins.
 - Review and trust new Codex hooks manually with `/hooks`.
 
 ### Fish plugins (managed by [`fisher`](https://github.com/jorgebucaran/fisher))

--- a/home/.chezmoiscripts/run_after_5-sync-ai-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/run_after_5-sync-ai-extensions.sh.tmpl
@@ -30,7 +30,4 @@ if command -v codex >/dev/null 2>&1; then
   grep -Fq '[plugins."{{ . }}"]' "$HOME/.codex/config.toml" 2>/dev/null ||
     within codex plugin add '{{ . }}' --json || :
 {{- end }}
-  if [[ -x "$HOME/.local/bin/zhtw-mcp" ]] && ! codex mcp get zhtw-mcp >/dev/null 2>&1; then
-    codex mcp add zhtw-mcp -- "$HOME/.local/bin/zhtw-mcp" >/dev/null || :
-  fi
 fi

--- a/home/.chezmoiscripts/run_onchange_after_0-install-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_0-install-packages.sh.tmpl
@@ -16,7 +16,11 @@ NC='\033[0m'
     {{ if .packages.arch.paru }}
     # Use -Syu to ensure system is up-to-date and libalpm version matches paru
     sudo pacman -Syu --noconfirm
-    paru -S --needed --noconfirm {{ range .packages.arch.paru }}{{ . }} {{ end }}
+    for attempt in 1 2 3; do
+      paru -S --needed --noconfirm {{ range .packages.arch.paru }}{{ . }} {{ end }} && break
+      (( attempt == 3 )) && exit 1
+      sleep 5
+    done
     {{ end }}
     
     if command -v flatpak > /dev/null; then

--- a/home/dot_claude/skills/symlink_respond-structured
+++ b/home/dot_claude/skills/symlink_respond-structured
@@ -1,1 +1,0 @@
-../../.agents/skills/respond-structured


### PR DESCRIPTION
## Summary

- keep shared user skills only under ~/.agents/skills for Codex and OpenCode
- remove the Claude compatibility skill symlink
- keep zhtw-mcp scoped to OpenCode instead of registering it in Codex
- retry transient AUR failures around the existing paru install

## Verification

- Arch Linux: passed
- Ubuntu: passed
- macOS: only the accepted VChewing 4.6.1 checksum mismatch remains
- rendered shell templates pass bash -n
- local duplicate skill copy and Codex zhtw-mcp registration were removed