### PR TITLE
ci: establish Windows runner baseline

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -52,3 +52,13 @@ jobs:
       - name: chezmoi init dotfiles
         run: |
           chezmoi init collieiscute --branch "$CHEZMOI_BRANCH" --apply -v
+
+  windows:
+    name: windows:latest
+    runs-on: windows-latest
+    steps:
+      - name: Install chezmoi and initialize dotfiles source
+        run: |
+          $binDir = Join-Path $env:RUNNER_TEMP "bin"
+          iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b '$binDir'"
+          & (Join-Path $binDir "chezmoi.exe") init collieiscute --branch "$env:CHEZMOI_BRANCH" -v


### PR DESCRIPTION
## Summary
- add a dedicated windows-latest CI job
- install chezmoi with its official PowerShell installer
- initialize the pushed branch without applying dotfiles

## Scope
This intentionally establishes only the Windows CI baseline. Scoop bootstrap, package installation, and full apply/idempotency checks remain for the follow-up Windows support change.

## Verification
- parsed the workflow with Ruby YAML
- ran git diff --check