### PR TITLE
feat: add Windows Scoop support

### DIFF
--- a/.github/workflows/test-distros.yaml
+++ b/.github/workflows/test-distros.yaml
@@ -57,8 +57,17 @@ jobs:
     name: windows:latest
     runs-on: windows-latest
     steps:
-      - name: Install chezmoi and initialize dotfiles source
+      - name: Install chezmoi and apply dotfiles twice
         run: |
           $binDir = Join-Path $env:RUNNER_TEMP "bin"
           iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b '$binDir'"
-          & (Join-Path $binDir "chezmoi.exe") init collieiscute --branch "$env:CHEZMOI_BRANCH" -v
+          $chezmoi = Join-Path $binDir "chezmoi.exe"
+          & $chezmoi init collieiscute --branch "$env:CHEZMOI_BRANCH" --apply -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & $chezmoi apply -v
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          $steam = & "$env:USERPROFILE\scoop\shims\scoop.cmd" prefix steam
+          if ($LASTEXITCODE -ne 0 -or !(Test-Path (Join-Path $steam "Steam.exe"))) {
+            throw "Steam installation was not found."
+          }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Ubuntu](https://img.shields.io/badge/Ubuntu-apt-E95420?logo=ubuntu&logoColor=white)
 ![Debian](https://img.shields.io/badge/Debian-apt-A81D33?logo=debian&logoColor=white)
 ![Mint](https://img.shields.io/badge/Linux%20Mint-apt-87CF3E?logo=linuxmint&logoColor=white)
+![Windows](https://img.shields.io/badge/Windows-Scoop-0078D4?logo=windows&logoColor=white)
 
 Personal dotfiles managed with [chezmoi](https://chezmoi.io). One repo, several machines.
 
@@ -22,6 +23,7 @@ chezmoi init --apply collieiscute -v
 | macOS | Homebrew | daily-driven |
 | Arch | pacman + paru | daily-driven |
 | Ubuntu / Debian / Linux Mint | apt | CI-tested only |
+| Windows | Scoop | CI-tested only |
 
 ## Custom touches worth knowing
 

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -145,3 +145,63 @@ packages:
       - xwayland
       - zip
       - zoxide
+  windows:
+    scoop:
+      main:
+        - bat
+        - btop
+        - chezmoi
+        - claude-code
+        - cloc
+        - cmake
+        - cppcheck
+        - curl
+        - dos2unix
+        - eza
+        - fastfetch
+        - fd
+        - fzf
+        - gh
+        - git
+        - glab
+        - go
+        - gping
+        - hugo
+        - llvm
+        - neovim
+        - ninja
+        - nodejs
+        - opencode
+        - openssh
+        - podman
+        - ripgrep
+        - tldr
+        - tokei
+        - typst
+        - unzip
+        - uv
+        - wget
+        - zellij
+        - zip
+        - zoxide
+      extras:
+        - alacritty
+        - brave
+        - flutter
+        - keepassxc
+        - lazygit
+        - libreoffice
+        - localsend
+        - mattermost
+        - moonlight
+        - neovide
+        - onefetch
+        - qmk-toolbox
+        - signal
+        - telegram
+        - vesktop
+        - vscode
+      games:
+        - steam
+      nerd-fonts:
+        - JetBrainsMono-NF

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -39,7 +39,9 @@ Library/**
 .config/wallpapers/**
 {{- end }}
 
-# Windows uses PowerShell run scripts.
+# Run scripts are platform-specific.
 {{- if eq .chezmoi.os "windows" }}
 .chezmoiscripts/*.sh
+{{- else }}
+.chezmoiscripts/*.ps1
 {{- end }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -38,3 +38,8 @@ Library/**
 .config/wallpapers
 .config/wallpapers/**
 {{- end }}
+
+# Windows uses PowerShell run scripts.
+{{- if eq .chezmoi.os "windows" }}
+.chezmoiscripts/*.sh
+{{- end }}

--- a/home/.chezmoiscripts/run_once_before_0-setup-package-manager.ps1
+++ b/home/.chezmoiscripts/run_once_before_0-setup-package-manager.ps1
@@ -1,4 +1,3 @@
-{{- if eq .chezmoi.os "windows" -}}
 $ErrorActionPreference = "Stop"
 $scoopRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $env:USERPROFILE "scoop" }
 $scoop = Join-Path $scoopRoot "shims\scoop.cmd"
@@ -11,4 +10,3 @@ if (!(Test-Path $scoop)) {
 if (!(Test-Path $scoop)) {
     throw "Scoop installation completed but $scoop was not found."
 }
-{{- end }}

--- a/home/.chezmoiscripts/run_once_before_0-setup-package-manager.ps1.tmpl
+++ b/home/.chezmoiscripts/run_once_before_0-setup-package-manager.ps1.tmpl
@@ -1,0 +1,14 @@
+{{- if eq .chezmoi.os "windows" -}}
+$ErrorActionPreference = "Stop"
+$scoopRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $env:USERPROFILE "scoop" }
+$scoop = Join-Path $scoopRoot "shims\scoop.cmd"
+
+if (!(Test-Path $scoop)) {
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+    Invoke-RestMethod -Uri "https://get.scoop.sh" | Invoke-Expression
+}
+
+if (!(Test-Path $scoop)) {
+    throw "Scoop installation completed but $scoop was not found."
+}
+{{- end }}

--- a/home/.chezmoiscripts/run_onchange_after_0-install-packages.ps1.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_0-install-packages.ps1.tmpl
@@ -1,0 +1,35 @@
+{{- if eq .chezmoi.os "windows" -}}
+$ErrorActionPreference = "Stop"
+$scoopRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $env:USERPROFILE "scoop" }
+$scoop = Join-Path $scoopRoot "shims\scoop.cmd"
+
+if (!(Test-Path $scoop)) {
+    throw "Scoop is not installed at $scoop."
+}
+
+function Invoke-Scoop {
+    & $scoop @args
+    if ($LASTEXITCODE -ne 0) {
+        throw "scoop $($args -join ' ') failed with exit code $LASTEXITCODE."
+    }
+}
+
+Invoke-Scoop install main/git
+Invoke-Scoop update
+
+foreach ($bucket in @("extras", "games", "nerd-fonts")) {
+    if (!(Test-Path (Join-Path $scoopRoot "buckets\$bucket"))) {
+        Invoke-Scoop bucket add $bucket
+    }
+}
+
+$packages = @(
+{{ range $bucket, $apps := .packages.windows.scoop -}}
+{{ range $apps -}}
+    "{{ $bucket }}/{{ . }}"
+{{ end -}}
+{{ end -}}
+)
+
+Invoke-Scoop install @packages
+{{- end }}

--- a/home/.chezmoiscripts/run_onchange_after_0-install-packages.ps1.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_0-install-packages.ps1.tmpl
@@ -1,4 +1,3 @@
-{{- if eq .chezmoi.os "windows" -}}
 $ErrorActionPreference = "Stop"
 $scoopRoot = if ($env:SCOOP) { $env:SCOOP } else { Join-Path $env:USERPROFILE "scoop" }
 $scoop = Join-Path $scoopRoot "shims\scoop.cmd"
@@ -32,4 +31,3 @@ $packages = @(
 )
 
 Invoke-Scoop install @packages
-{{- end }}

--- a/home/dot_config/alacritty/alacritty.toml.tmpl
+++ b/home/dot_config/alacritty/alacritty.toml.tmpl
@@ -1,7 +1,9 @@
 [general]
 import = [
     "~/.config/alacritty/catppuccin-mocha.toml",
+{{- if eq .chezmoi.os "linux" }}
     "~/.config/alacritty/themes/noctalia.toml",
+{{- end }}
 ]
 
 [window]

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -40,12 +40,12 @@
     "zhtw-mcp": {
       "type": "local",
       "command": [
-        "{{ .chezmoi.homeDir }}/.local/bin/zhtw-mcp"
+        {{ printf "%s/.local/bin/zhtw-mcp" .chezmoi.homeDir | toJson }}
       ],
       "enabled": true
     }
   },
   "instructions": [
-    "{{ .chezmoi.homeDir }}/.config/opencode/instructions/zh-tw.md"
+    {{ printf "%s/.config/opencode/instructions/zh-tw.md" .chezmoi.homeDir | toJson }}
   ]
 }


### PR DESCRIPTION
## Summary

- bootstrap Scoop from chezmoi and install the complete 54-package Windows inventory, including Steam
- select Bash or PowerShell run scripts centrally in `.chezmoiignore`
- make Alacritty and OpenCode output valid on Windows
- run a full Windows apply twice in CI and verify the Steam installation

## Verification

- Windows full `chezmoi apply --dry-run` passed
- managed script matrix: Windows `0 sh / 2 ps1`; macOS and Linux `7 sh / 0 ps1`
- package data and workflow YAML parsed successfully
- all 54 Scoop package arguments rendered successfully

Follow-up to #105, which established the Windows runner baseline.